### PR TITLE
fix dst begin

### DIFF
--- a/elektra/elektra.py
+++ b/elektra/elektra.py
@@ -397,6 +397,12 @@ def create_prices(flow_date, ticker, node, iso, block, frequency, input_prices):
                            ignore_index=True)
             log.debug('I am relevant: {0} HE {1}'.format(dh.strftime('%Y-%m-%d'), he))
 
+    # if flow date is the beginning of daylight savings and there are 23 input prices in order from 1-23
+    # adjust hours 3-23 so the result is hours 1, 2, 4..24
+    if is_dst_transition(as_of=flow_date)[1] and input_prices.hour_ending.size == 23 and pd.to_numeric(input_prices.hour_ending).max() == 23:
+        log.info('input prices need to be adjusted to skip hour 3')
+        input_prices.loc[:, 'hour_ending'] = input_prices.hour_ending.map(lambda he: he + 1 if he > 2 else he)
+
     # Fill required hours table with data. Barf if we're missing something.
     # Nice-to-have: Fill it backwards (because it's more likely we won't have the ending settles)
     # df.to_csv('outputs/required - '+ticker+'.csv')
@@ -474,6 +480,12 @@ def scrub_hourly_prices(flow_date, ticker, node, iso, input_prices):
                            ignore_index=True)
             log.debug('I am relevant: {0} HE {1}'.format(dh.strftime('%Y-%m-%d'), he))
 
+    # if flow date is the beginning of daylight savings and there are 23 input prices in order from 1-23
+    # adjust hours 3-23 so the result is hours 1, 2, 4..24
+    if is_dst_transition(as_of=flow_date)[1] and input_prices.hour_ending.size == 23 and pd.to_numeric(input_prices.hour_ending).max() == 23:
+        log.info('input prices need to be adjusted to skip hour 3')
+        input_prices.loc[:, 'hour_ending'] = input_prices.hour_ending.map(lambda he: he + 1 if he > 2 else he)
+    
     # Fill required hours table with data. Barf if we're missing something.
     # Nice-to-have: Fill it backwards (because it's more likely we won't have the ending settles)
     # df.to_csv('outputs/required - '+ticker+'.csv')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pandas
+pandas==1.4.2
 numpy==1.24.2
 wheel==0.36.2
-pytz
-python-dateutil
+pytz==2022.1
+python-dateutil==2.8.2

--- a/tests/consecutive_dst_begin_data.json
+++ b/tests/consecutive_dst_begin_data.json
@@ -1,0 +1,126 @@
+{
+    "as_of": "2024-05-13",
+    "flow_date": "2024-03-10",
+    "ticker": "E.4MYV.DADL9",
+    "node": "ISONE MASS HUB",
+    "iso": "iso_ne",
+    "block": "Wrap",
+    "frequency": "Daily",
+    "data": [
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 1,
+            "price": "20.43"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 2,
+            "price": "17.51"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 3,
+            "price": "17.38"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 4,
+            "price": "16.92"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 5,
+            "price": "17.74"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 6,
+            "price": "18.07"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 7,
+            "price": "20.0"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 8,
+            "price": "19.86"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 9,
+            "price": "21.69"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 10,
+            "price": "21.82"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 11,
+            "price": "20.7"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 12,
+            "price": "20.76"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 13,
+            "price": "19.88"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 14,
+            "price": "20.1"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 15,
+            "price": "19.38"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 16,
+            "price": "20.29"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 17,
+            "price": "28.96"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 18,
+            "price": "31.46"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 19,
+            "price": "33.61"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 20,
+            "price": "32.95"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 21,
+            "price": "29.85"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 22,
+            "price": "21.55"
+        },
+        {
+            "flow_date": "2024-03-10",
+            "hour_ending": 23,
+            "price": "20.86"
+        }
+    ]
+}

--- a/tests/test_dst.py
+++ b/tests/test_dst.py
@@ -1,0 +1,68 @@
+import unittest
+import datetime
+import json
+import pandas as pd
+import elektra
+
+
+class DstBegin2024Tests(unittest.TestCase):
+    def setUp(self):
+        self.flow_date = datetime.datetime(2024, 3, 10)
+        self.ticker = 'E.4MYV.DADL9'
+        self.node = 'ISONE MASS HUB'
+        self.iso = 'isone'
+        self.frequency = 'daily'
+        self.consecutive_dst_begin_prices = self.get_consecutive_dst_begin_prices()
+
+    def get_consecutive_dst_begin_prices(self):
+        with open('tests/consecutive_dst_begin_data.json') as f:
+            data = json.loads(f.read())
+        return pd.DataFrame(data['data'])
+
+    def test_consecutive_dst_begin_prices_2x16(self):
+        p = elektra.create_prices(
+            flow_date=self.flow_date,
+            ticker=self.ticker,
+            node=self.node,
+            iso=self.iso,
+            block='2x16',
+            frequency=self.frequency,
+            input_prices=self.consecutive_dst_begin_prices
+        )
+        self.assertAlmostEqual(23.928750, p, places=6)
+
+    def test_consecutive_dst_begin_prices_7x24(self):
+        p = elektra.create_prices(
+            flow_date=self.flow_date,
+            ticker=self.ticker,
+            node=self.node,
+            iso=self.iso,
+            block='7x24',
+            frequency=self.frequency,
+            input_prices=self.consecutive_dst_begin_prices
+        )
+        self.assertAlmostEqual(22.250870, p, places=6)
+
+    def test_consecutive_dst_begin_prices_wrap(self):
+        p = elektra.create_prices(
+            flow_date=self.flow_date,
+            ticker=self.ticker,
+            node=self.node,
+            iso=self.iso,
+            block='wrap',
+            frequency=self.frequency,
+            input_prices=self.consecutive_dst_begin_prices
+        )
+        self.assertAlmostEqual(22.250870, p, places=6)
+
+    def test_consecutive_dst_begin_prices_7x8(self):
+        p = elektra.create_prices(
+            flow_date=self.flow_date,
+            ticker=self.ticker,
+            node=self.node,
+            iso=self.iso,
+            block='7x8',
+            frequency=self.frequency,
+            input_prices=self.consecutive_dst_begin_prices
+        )
+        self.assertAlmostEqual(18.415714, p, places=6)


### PR DESCRIPTION
added an enhancement for creating aggregate prices to support consecutive hours 1..23 on dst begin days instead of only supporting hours 1, 2, 4..24